### PR TITLE
Always specify the exception type in except: blocks

### DIFF
--- a/fabulous/utils.py
+++ b/fabulous/utils.py
@@ -92,7 +92,7 @@ class TerminalInfo(object):
         """
         try:
             call = fcntl.ioctl(self.termfd, termios.TIOCGWINSZ, "\000" * 8)
-        except:
+        except IOError:
             return (79, 40)
         else:
             height, width = struct.unpack("hhhh", call)[:2]

--- a/fabulous/xterm256.py
+++ b/fabulous/xterm256.py
@@ -91,7 +91,8 @@ def compile_speedup():
     sauce = join(dirname(__file__), '_xterm256.c')
     if not exists(library) or getmtime(sauce) > getmtime(library):
         build = "gcc -fPIC -shared -o %s %s" % (library, sauce)
-        assert os.system(build + " >/dev/null 2>&1") == 0
+        if (os.system(build + " >/dev/null 2>&1") != 0):
+            raise OSError("GCC error")
     xterm256_c = ctypes.cdll.LoadLibrary(library)
     xterm256_c.init()
     def xterm_to_rgb(xcolor):
@@ -102,5 +103,5 @@ def compile_speedup():
 
 try:
     (rgb_to_xterm, xterm_to_rgb) = compile_speedup()
-except:
+except OSError:
     logging.debug("fabulous failed to compile xterm256 speedup code")


### PR DESCRIPTION
An unspecified except: also catches KeyboardInterrupts and the like,
which isn't very nice :-)
