### PR TITLE
Ship balls.png.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include LICENSE.txt
 include MANIFEST.in
 include ez_setup.py
 include fabulous/_xterm256.c
+include fabulous/balls.png
 include fabulous/fonts/LICENSE
 include fabulous/fonts/NotoEmoji-Regular.ttf
 include fabulous/fonts/NotoSans-Bold.ttf


### PR DESCRIPTION
The code expects it to be there, but it does not get included in the
tarball uploaded to pypi.

This should include it in future releases.

Cheers!
