### PR TITLE
'basestring' is not defined error for python3

### DIFF
--- a/fabulous/image.py
+++ b/fabulous/image.py
@@ -112,7 +112,7 @@ class Image(object):
         (iw, ih) = self.size
         if width is None:
             width = min(iw, utils.term.width)
-        elif isinstance(width, basestring):
+        elif isinstance(width, str):
             percents = dict([(pct, '%s%%' % (pct)) for pct in range(101)])
             width = percents[width]
         height = int(float(ih) * (float(width) / float(iw)))


### PR DESCRIPTION
When I tried print png file on terminal with **width** parameter, error occurs:
`NameError: name 'basestring' is not defined`

"basestring" not available in python3.
This issue can be fix with <basestring = str> change.

_ref: https://stackoverflow.com/questions/34803467/unexpected-exception-name-basestring-is-not-defined-when-invoking-ansible2_