### PR TITLE
Added basestring check to image.py

### DIFF
--- a/fabulous/image.py
+++ b/fabulous/image.py
@@ -28,8 +28,15 @@
 import sys
 import itertools
 
+from six import string_types
+
 from fabulous import utils, xterm256, grapefruit
 from fabulous.compatibility import printy
+
+try:
+    basestring = basestring
+except:
+    basestring = (str, bytes)
 
 
 class Image(object):
@@ -112,7 +119,7 @@ class Image(object):
         (iw, ih) = self.size
         if width is None:
             width = min(iw, utils.term.width)
-        elif isinstance(width, basestring):
+        elif isinstance(width, string_types):
             percents = dict([(pct, '%s%%' % (pct)) for pct in range(101)])
             width = percents[width]
         height = int(float(ih) * (float(width) / float(iw)))

--- a/fabulous/image.py
+++ b/fabulous/image.py
@@ -28,8 +28,6 @@
 import sys
 import itertools
 
-from six import string_types
-
 from fabulous import utils, xterm256, grapefruit
 from fabulous.compatibility import printy
 
@@ -119,7 +117,7 @@ class Image(object):
         (iw, ih) = self.size
         if width is None:
             width = min(iw, utils.term.width)
-        elif isinstance(width, string_types):
+        elif isinstance(width, basestring):
             percents = dict([(pct, '%s%%' % (pct)) for pct in range(101)])
             width = percents[width]
         height = int(float(ih) * (float(width) / float(iw)))


### PR DESCRIPTION
Noticed errors when using Python3.6 when the Image.resize() method did a instance check on `basestring`. I noted in the commit message that a possibility would be to continue using the try..catch statement to define basestring if it doesn't exist, but the option remains of using packages like `six` and `future.utils`. However this would mean importing more packages which would be inefficient for just a  basestring implementation/replacement.