### PR TITLE
Added 24-bit "truecolor" support, tweaked font paths.

### DIFF
--- a/fabulous/color.py
+++ b/fabulous/color.py
@@ -138,7 +138,7 @@ class ColorStringTrue(ColorString):
 
     def __str__(self):
         return self.fmt % (
-            *self.color, self.sep.join([unicode(s) for s in self.items]))
+            self.color[0], self.color[1], self.color[2], self.sep.join([unicode(s) for s in self.items]))
 
 class plain(ColorString):
     r"""Plain text wrapper
@@ -925,7 +925,8 @@ class complementtrue(ColorStringTrue):
 
     def __str__(self):
         return self.fmt % (
-            *self.fg, *self.bg,
+            self.fg[0], self.fg[1], self.fg[2],
+			self.bg[0], self.bg[1], self.bg[2],
             self.sep.join([unicode(s) for s in self.items]))
 
 

--- a/fabulous/color.py
+++ b/fabulous/color.py
@@ -124,6 +124,28 @@ class ColorString(object):
         """A more readable way to say ``unicode(color).encode('utf8')``
         """
         return unicode(self).encode('utf8')
+    def join(self, iterable):
+        """
+        This works just like `str.join()`, but for ColorStrings!
+
+        For example:
+
+            >>> from fabulous.color import *
+            >>> l = [
+            ...     fg256("green", "napster good"),
+            ...     fg256("red", "fire bad"),
+            ... ]
+            >>> print(plain(" ").join(l))
+
+        """
+        ret = None
+        for x in iterable:
+            if ret is None:
+                ret = x
+            else:
+                ret += self
+                ret += x
+        return ret
 
 
 class ColorString256(ColorString):

--- a/fabulous/color.py
+++ b/fabulous/color.py
@@ -74,6 +74,10 @@ class ColorString(object):
         >>> len(bold("hello ", red("world")))
         11
 
+    If you have the wcwidth module installed, it will be used for computing lengths::
+
+
+
     """
     sep = ""
     fmt = "%s"
@@ -87,8 +91,21 @@ class ColorString(object):
     def __repr__(self):
         return repr(unicode(self))
 
-    def __len__(self):
-        return sum([len(item) for item in self.items])
+
+    if sys.version_info[0] > 2:
+        def __len__(self):
+            try:
+                import wcwidth
+                # We use:
+                # * wcwidth.wcswidth(item) to find the length of strs
+                # * len(str(item)) to find the length of a bytes object
+                # * len(item) for everything else.
+                return sum([ wcwidth.wcswidth(item) if isinstance(item, str) else len(str(item)) if isinstance(item, bytes) else len(item) for item in self.items ])
+            except ModuleNotFoundError:
+                return sum([len(str(item)) if isinstance(item, bytes) else len(item) for item in self.items])
+    else:
+        def __len__(self):
+            return sum([len(item) for item in self.items])
 
     def __add__(self, cs):
         if not isinstance(cs, (basestring, ColorString)):
@@ -926,7 +943,7 @@ class complementtrue(ColorStringTrue):
     def __str__(self):
         return self.fmt % (
             self.fg[0], self.fg[1], self.fg[2],
-			self.bg[0], self.bg[1], self.bg[2],
+            self.bg[0], self.bg[1], self.bg[2],
             self.sep.join([unicode(s) for s in self.items]))
 
 

--- a/fabulous/text.py
+++ b/fabulous/text.py
@@ -175,6 +175,13 @@ def resolve_font(name):
         return fonts[name]
     raise FontNotFound("Can't find %r :'(  Try adding it to ~/.fonts" % name)
 
+font_roots = [
+    '/usr/share/fonts/truetype',                # where ubuntu puts fonts
+    '/usr/share/fonts',                         # where fedora puts fonts
+    os.path.expanduser('~/.local/share/fonts'), # custom user fonts
+    os.path.expanduser('~/.fonts'),             # custom user fonts
+    os.path.abspath(os.path.join(os.path.dirname(__file__), 'fonts')),
+]
 
 @utils.memoize
 def get_font_files():
@@ -193,14 +200,8 @@ def get_font_files():
         True
 
     """
-    roots = [
-        '/usr/share/fonts/truetype',     # where ubuntu puts fonts
-        '/usr/share/fonts',              # where fedora puts fonts
-        os.path.expanduser('~/.fonts'),  # custom user fonts
-        os.path.abspath(os.path.join(os.path.dirname(__file__), 'fonts')),
-    ]
     result = {}
-    for root in roots:
+    for root in font_roots:
         for path, dirs, names in os.walk(root):
             for name in names:
                 if name.endswith(('.ttf', '.otf')):


### PR DESCRIPTION
Created classes `ColorStringTrue`, `fgtrue`, `bgtrue`, `highlighttrue`, and `complementtrue` to color.py, in order to support the increasing number of terminals that support full 24-bit color.

Also made the following changes to text.py:

* Moved the `roots` font directory search list that was embedded into `get_font_files()` out to `font_roots`, so that it can be modified/monkeypatched externally.
* Added `~/.local/share/fonts` to the font directory search list.