### PR TITLE
Fix compatibility with Pillow 10

### DIFF
--- a/fabulous/text.py
+++ b/fabulous/text.py
@@ -115,7 +115,7 @@ class Text(image.Image):
         self.color = grapefruit.Color.NewFromHtml(color)
         self.font = ImageFont.truetype(resolve_font(font), fsize)
         skew = skew or 0
-        size = tuple([n + 3 + skew for n in self.font.getsize(self.text)])
+        size = tuple([n + 3 + skew for n in self.font.getbbox(self.text)[2:]])
         self.img = Image.new("RGBA", size, (0, 0, 0, 0))
         cvs = ImageDraw.Draw(self.img)
         if shadow:


### PR DESCRIPTION
The `FreeTypeFont.getsize()` method is removed:
https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#font-size-and-offset-methods